### PR TITLE
chore(test): refactor tf backend usage

### DIFF
--- a/.github/workflows/ci-integration-test.yaml
+++ b/.github/workflows/ci-integration-test.yaml
@@ -21,8 +21,8 @@ jobs:
       ARM_TENANT_ID: ${{secrets.AZURE_ARM_TENANT_ID}}
       TF_VAR_subscription_id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
       TF_VAR_sysdig_secure_api_token: ${{secrets.KUBELAB_SECURE_API_TOKEN}}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_QA_CLOUDNATIVE_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
 
     steps:

--- a/test/fixtures/single-account/backend.tf
+++ b/test/fixtures/single-account/backend.tf
@@ -1,9 +1,9 @@
 # Terraform state storage backend
 terraform {
   backend "s3" {
-    bucket         = "kitchentest-terraform"
+    bucket         = "secure-cloud-terraform-tests"
     key            = "azure-single/terraform.tfstate"
-    dynamodb_table = "kitchen_test"
+    dynamodb_table = "secure-cloud-terraform-tests"
     region         = "eu-west-3"
   }
 }


### PR DESCRIPTION
terraform backend cleanup. will use AWS QA org cloudnative member account
- aws | https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/pull/31
- google | https://github.com/sysdiglabs/terraform-google-secure-for-cloud/pull/62
- azure | https://github.com/sysdiglabs/terraform-azurerm-secure-for-cloud/pull/27