### PR TITLE
fix(bench) Pass subscription ID correctly

### DIFF
--- a/examples/single-subscription-k8s/cloudbench.tf
+++ b/examples/single-subscription-k8s/cloudbench.tf
@@ -1,6 +1,6 @@
 module "cloud_bench" {
   count           = var.deploy_benchmark ? 1 : 0
   source          = "../../modules/services/cloud-bench"
-  subscription_id = data.azurerm_subscription.current.id
+  subscription_id = data.azurerm_subscription.current.subscription_id
   region          = var.region
 }

--- a/examples/single-subscription/cloudbench.tf
+++ b/examples/single-subscription/cloudbench.tf
@@ -1,6 +1,6 @@
 module "cloud_bench" {
   count           = var.deploy_benchmark ? 1 : 0
   source          = "../../modules/services/cloud-bench"
-  subscription_id = data.azurerm_subscription.current.id
+  subscription_id = data.azurerm_subscription.current.subscription_id
   region          = var.region
 }


### PR DESCRIPTION
we are passing the id ("/subscriptions/c3ea21a5-e474-4ed3-bf6c-b35fe3f9bea1") [here](https://github.com/sysdiglabs/terraform-azurerm-secure-for-cloud/blob/master/examples/single-subscription/cloudbench.tf#L4) instead of the subscription_id ("c3ea21a5-e474-4ed3-bf6c-b35fe3f9bea1"), which is causing the malformed /subscriptions//subscriptions/c3ea21a5-e474-4ed3-bf6c-b35fe3f9bea1 in the module.