### PR TITLE
Set owner in service principal/app creation (ESC-1593)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.50.0
     hooks:
       - id: terraform_fmt
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/modules/infrastructure/enterprise_app/README.md
+++ b/modules/infrastructure/enterprise_app/README.md
@@ -28,7 +28,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_client_config](https://registry.terraform.io/providers/hashicorp/azuread/2.14.0/docs/data-sources/client_config) | data |
+| [azuread_client_config](https://registry.terraform.io/providers/hashicorp/azuread/2.14.0/docs/data-sources/client_config) | data source |
 | [azuread_application.aa](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application) | resource |
 | [azuread_application_password.aap](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application_password) | resource |
 | [azuread_service_principal.asp](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/service_principal) | resource |

--- a/modules/infrastructure/enterprise_app/README.md
+++ b/modules/infrastructure/enterprise_app/README.md
@@ -28,6 +28,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azuread_client_config](https://registry.terraform.io/providers/hashicorp/azuread/2.14.0/docs/data-sources/client_config) | data |
 | [azuread_application.aa](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application) | resource |
 | [azuread_application_password.aap](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application_password) | resource |
 | [azuread_service_principal.asp](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/service_principal) | resource |

--- a/modules/infrastructure/enterprise_app/README.md
+++ b/modules/infrastructure/enterprise_app/README.md
@@ -28,13 +28,13 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_client_config](https://registry.terraform.io/providers/hashicorp/azuread/2.14.0/docs/data-sources/client_config) | data source |
 | [azuread_application.aa](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application) | resource |
 | [azuread_application_password.aap](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/application_password) | resource |
 | [azuread_service_principal.asp](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.aspp](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/resources/service_principal_password) | resource |
 | [azurerm_role_assignment.main](https://registry.terraform.io/providers/hashicorp/azurerm/2.85.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.ard](https://registry.terraform.io/providers/hashicorp/azurerm/2.85.0/docs/resources/role_definition) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.7.0/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/modules/infrastructure/enterprise_app/main.tf
+++ b/modules/infrastructure/enterprise_app/main.tf
@@ -2,12 +2,20 @@ locals {
   scopes = toset([for s in var.subscription_ids : "/subscriptions/${s}"])
 }
 
+data "azuread_client_config" "current" {}
+
 resource "azuread_application" "aa" {
   display_name = "${var.name}-sd-app"
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
 }
 
 resource "azuread_service_principal" "asp" {
   application_id = azuread_application.aa.application_id
+  owners = [
+    data.azuread_client_config.current.object_id
+  ]
 }
 
 resource "azuread_service_principal_password" "aspp" {


### PR DESCRIPTION
`Owner` attribute should be specified when creating an azure app and service principal within the app to avoid an intermittent 403 error 
(https://sysdig.atlassian.net/browse/ESC-1593)


@nestorsalceda this PR also updates `.pre-commit-config.yaml` to use `https:` instead of `git:` for the repo urls; this was causing the pre-commit to fail as Git recently removed unencrypted Git protocol support (https://github.blog/2021-09-01-improving-git-protocol-security-github/) 