### PR TITLE
fix: add random name to registry

### DIFF
--- a/modules/infrastructure/container_registry/README.md
+++ b/modules/infrastructure/container_registry/README.md
@@ -10,12 +10,14 @@ Deploys a container registry and creates an Event Grid to send Image Push and Ch
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.85.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.85.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >=3.1.0 |
 
 ## Modules
 
@@ -27,6 +29,7 @@ No modules.
 |------|------|
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/2.85.0/docs/resources/container_registry) | resource |
 | [azurerm_eventgrid_event_subscription.default](https://registry.terraform.io/providers/hashicorp/azurerm/2.85.0/docs/resources/eventgrid_event_subscription) | resource |
+| [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [azurerm_container_registry.example](https://registry.terraform.io/providers/hashicorp/azurerm/2.85.0/docs/data-sources/container_registry) | data source |
 
 ## Inputs

--- a/modules/infrastructure/container_registry/main.tf
+++ b/modules/infrastructure/container_registry/main.tf
@@ -2,9 +2,17 @@ locals {
   deploy_container_registry = var.registry_name == ""
 }
 
+resource "random_string" "random" {
+  length  = 5
+  lower   = true
+  upper   = false
+  special = false
+  number  = false
+}
+
 resource "azurerm_container_registry" "acr" {
   count               = local.deploy_container_registry ? 1 : 0
-  name                = "${lower(var.name)}containerregistry"
+  name                = "containerregistry${lower(var.name)}${random_string.random.result}"
   resource_group_name = var.resource_group_name
   location            = var.location
   sku                 = var.sku

--- a/modules/infrastructure/container_registry/versions.tf
+++ b/modules/infrastructure/container_registry/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "2.85.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.1.0"
+    }
   }
 }


### PR DESCRIPTION
This PR includes a fix to create a the container registry with random name to avoid name collisions. 
