### PR TITLE
chore: use the same variable name

### DIFF
--- a/examples/tenant-subscriptions/README.md
+++ b/examples/tenant-subscriptions/README.md
@@ -110,7 +110,7 @@ Notice that:
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig's Secure API Token | `string` | n/a | yes |
 | <a name="input_benchmark_subscription_ids"></a> [benchmark\_subscription\_ids](#input\_benchmark\_subscription\_ids) | Azure subscription IDs to run Benchmarks on. If no subscriptions are specified, all of the tenant will be used. | `list(string)` | `[]` | no |
 | <a name="input_deploy_active_directory"></a> [deploy\_active\_directory](#input\_deploy\_active\_directory) | whether the Active Directory features are to be deployed | `bool` | `true` | no |
-| <a name="input_deploy_bench"></a> [deploy\_bench](#input\_deploy\_bench) | whether benchmark module is to be deployed | `bool` | `true` | no |
+| <a name="input_deploy_benchmark"></a> [deploy\_benchmark](#input\_deploy\_benchmark) | whether benchmark module is to be deployed | `bool` | `true` | no |
 | <a name="input_deploy_scanning"></a> [deploy\_scanning](#input\_deploy\_scanning) | whether scanning module is to be deployed | `bool` | `true` | no |
 | <a name="input_location"></a> [location](#input\_location) | Zone where the stack will be deployed | `string` | `"westus"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |

--- a/examples/tenant-subscriptions/main.tf
+++ b/examples/tenant-subscriptions/main.tf
@@ -97,7 +97,7 @@ provider "sysdig" {
 }
 
 module "cloud_bench" {
-  count  = var.deploy_bench ? 1 : 0
+  count  = var.deploy_benchmark ? 1 : 0
   source = "../../modules/services/cloud-bench"
 
   subscription_ids = local.benchmark_subscription_ids

--- a/examples/tenant-subscriptions/variables.tf
+++ b/examples/tenant-subscriptions/variables.tf
@@ -78,7 +78,7 @@ variable "threat_detection_subscription_ids" {
   description = "Azure subscription IDs to run threat detection on. If no subscriptions are specified, all of the tenant will be used."
 }
 
-variable "deploy_bench" {
+variable "deploy_benchmark" {
   type        = bool
   description = "whether benchmark module is to be deployed"
   default     = true


### PR DESCRIPTION
Change the variable name deploy_bench to deploy_benchmarck in tenant-subscription example.