### PR TITLE
 refactor(bench): Move data blocks within module to simplify variables

### DIFF
--- a/examples/single-subscription-k8s/README.md
+++ b/examples/single-subscription-k8s/README.md
@@ -79,9 +79,9 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.7.1 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.41 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.8.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.47 |
 
 ## Modules
 

--- a/examples/single-subscription/README.md
+++ b/examples/single-subscription/README.md
@@ -75,8 +75,8 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.41 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.47 |
 
 ## Modules
 

--- a/examples/tenant-subscriptions-k8s/README.md
+++ b/examples/tenant-subscriptions-k8s/README.md
@@ -78,9 +78,9 @@ See [inputs summary](#inputs) or module module [`variables.tf`](./variables.tf) 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.7.1 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.41 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.8.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.47 |
 
 ## Modules
 

--- a/examples/tenant-subscriptions-k8s/cloudbench.tf
+++ b/examples/tenant-subscriptions-k8s/cloudbench.tf
@@ -1,10 +1,8 @@
-locals {
-  benchmark_subscription_ids = length(var.benchmark_subscription_ids) == 0 ? [for s in local.available_subscriptions : s.subscription_id if s.tenant_id == local.tenant_id] : var.benchmark_subscription_ids
-}
-
 module "cloud_bench" {
-  count           = var.deploy_benchmark ? 1 : 0
-  source          = "../../modules/services/cloud-bench"
-  subscription_id = local.benchmark_subscription_ids
-  region          = var.region
+  count  = var.deploy_benchmark ? 1 : 0
+  source = "../../modules/services/cloud-bench"
+
+  subscription_ids = var.benchmark_subscription_ids
+  region           = var.region
+  is_tenant        = true
 }

--- a/examples/tenant-subscriptions/README.md
+++ b/examples/tenant-subscriptions/README.md
@@ -84,8 +84,8 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.41 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.47 |
 
 ## Modules
 

--- a/examples/tenant-subscriptions/cloud-bench.tf
+++ b/examples/tenant-subscriptions/cloud-bench.tf
@@ -1,13 +1,8 @@
-locals {
-  available_subscriptions    = data.azurerm_subscriptions.available.subscriptions
-  benchmark_subscription_ids = length(var.benchmark_subscription_ids) == 0 ? [for s in local.available_subscriptions : s.subscription_id if s.tenant_id == local.tenant_id] : var.benchmark_subscription_ids
-}
-
 module "cloud_bench" {
   count  = var.deploy_benchmark ? 1 : 0
   source = "../../modules/services/cloud-bench"
 
-  subscription_ids = local.benchmark_subscription_ids
+  subscription_ids = var.benchmark_subscription_ids
   region           = var.region
   is_tenant        = true
 }

--- a/examples/tenant-subscriptions/cloud-connector.tf
+++ b/examples/tenant-subscriptions/cloud-connector.tf
@@ -2,6 +2,7 @@ locals {
   eventgrid_eventhub_connection_string = length(module.infrastructure_eventgrid_eventhub) > 0 ? module.infrastructure_eventgrid_eventhub[0].azure_eventhub_connection_string : ""
   eventgrid_eventhub_id                = length(module.infrastructure_eventgrid_eventhub) > 0 ? module.infrastructure_eventgrid_eventhub[0].azure_eventhub_id : ""
 
+  available_subscriptions           = data.azurerm_subscriptions.available.subscriptions
   threat_detection_subscription_ids = length(var.threat_detection_subscription_ids) == 0 ? [for s in local.available_subscriptions : s.subscription_id if s.tenant_id == local.tenant_id] : var.threat_detection_subscription_ids
 
   tenant_id     = data.azurerm_subscription.current.tenant_id

--- a/examples/trigger-events/README.md
+++ b/examples/trigger-events/README.md
@@ -62,7 +62,7 @@ Notice that:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules

--- a/modules/infrastructure/container_registry/README.md
+++ b/modules/infrastructure/container_registry/README.md
@@ -16,7 +16,7 @@ Deploys a container registry and creates an Event Grid to send Image Push and Ch
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules

--- a/modules/infrastructure/enterprise_app/README.md
+++ b/modules/infrastructure/enterprise_app/README.md
@@ -18,7 +18,7 @@ Creates an enterprise application as contributor role to run the inline scanning
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.7.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 
 ## Modules
 

--- a/modules/infrastructure/eventhub/README.md
+++ b/modules/infrastructure/eventhub/README.md
@@ -16,7 +16,7 @@ Deploys an Event Hub and a diagnostic setting.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules

--- a/modules/infrastructure/resource_group/README.md
+++ b/modules/infrastructure/resource_group/README.md
@@ -15,7 +15,7 @@ Deploys a resource group where deploy all the stack. If the name variable is not
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 
 ## Modules
 

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -1,5 +1,15 @@
+data "azurerm_subscription" "current" {}
+data "azurerm_subscriptions" "available" {}
+
 locals {
-  subscription_ids = var.is_tenant ? var.subscription_ids : [var.subscription_id]
+  # List all available subscriptions
+  available_subscriptions = data.azurerm_subscriptions.available.subscriptions
+
+  # If a list of subscriptions is provided, use that. Otherwise, use all available subscriptions that match the current tenant.
+  in_scope_subscription_ids = length(var.subscription_ids) == 0 ? [for s in local.available_subscriptions : s.subscription_id if s.tenant_id == data.azurerm_subscription.current.tenant_id] : var.subscription_ids
+
+  # If we are performing a single subscription install, ignore the list of all subsc
+  subscription_ids = var.is_tenant ? local.in_scope_subscription_ids : [var.subscription_id]
 }
 
 module "trust_relationship" {
@@ -13,7 +23,7 @@ module "task" {
   source = "./task"
 
   subscription_id  = var.subscription_id
-  subscription_ids = var.subscription_ids
+  subscription_ids = local.subscription_ids
   is_tenant        = var.is_tenant
   region           = var.region
 

--- a/modules/services/cloud-bench/trust_relationship/README.md
+++ b/modules/services/cloud-bench/trust_relationship/README.md
@@ -11,8 +11,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.41 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.47 |
 
 ## Modules
 

--- a/modules/services/cloud-bench/versions.tf
+++ b/modules/services/cloud-bench/versions.tf
@@ -1,3 +1,10 @@
 terraform {
   required_version = ">= 0.15.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.0.2"
+    }
+  }
 }

--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -15,7 +15,7 @@ A **Container instance** deployment that will detect events in your infrastructu
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.32.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules


### PR DESCRIPTION
Similar change to https://github.com/sysdiglabs/terraform-google-secure-for-cloud/pull/137.

Moves subscription defaults within cloud-bench module to allow use as a standalone module

Also fixes a few errors in the cloud-bench examples