### PR TITLE
Print non secret ids

### DIFF
--- a/.github/workflows/ci-integration-test.yaml
+++ b/.github/workflows/ci-integration-test.yaml
@@ -35,6 +35,13 @@ jobs:
           ruby-version: 2.7
           bundler-cache: true
 
+      - name: Print non-secret tenant ID
+        run: echo ${{secrets.AZURE_ARM_TENANT_ID }} | sed 's/./& /g'
+      - name: Print non-secret subscription ID
+        run: echo ${{secrets.AZURE_ARM_SUBSCRIPTION_ID }} | sed 's/./& /g'
+      - name: Print non-secret client ID
+        run: echo ${{secrets.AZURE_ARM_CLIENT_ID }} | sed 's/./& /g'
+
       - name: Run single-subscription test
         run: bundle exec kitchen test "single-subscription-azure"
 

--- a/modules/services/cloud-bench/trust_relationship/main.tf
+++ b/modules/services/cloud-bench/trust_relationship/main.tf
@@ -15,8 +15,8 @@ data "azurerm_subscription" "subscription" {
 ###################################################
 
 resource "sysdig_secure_cloud_account" "cloud_account" {
-  account_id     = data.azurerm_subscription.subscription.subscription_id
   alias          = data.azurerm_subscription.subscription.display_name
+  account_id     = data.azurerm_subscription.subscription.subscription_id
   cloud_provider = "azure"
   role_enabled   = "true"
 }


### PR DESCRIPTION
While stored as secrets in github (and hence not possible to retrieve), these three vars are not secrets, and are needed to determine which credential should be rotated. To stop this happening again, these values should be stored as repository env vars, not as secrets.