### PR TITLE
feat: enable log level param under single-subscription installation

### DIFF
--- a/examples/single-subscription/cloud-connector.tf
+++ b/examples/single-subscription/cloud-connector.tf
@@ -47,4 +47,5 @@ module "cloud_connector" {
   memory = var.memory
 
   tags = var.tags
+  logging = var.logging
 }

--- a/examples/single-subscription/variables.tf
+++ b/examples/single-subscription/variables.tf
@@ -82,3 +82,9 @@ variable "tags" {
     product = "sysdig-secure-for-cloud"
   }
 }
+
+variable "logging" {
+  type        = string
+  description = "log level: info or debug"
+  default = "info"
+}

--- a/modules/services/cloud-connector/cloudconnector-config.tf
+++ b/modules/services/cloud-connector/cloudconnector-config.tf
@@ -1,6 +1,6 @@
 locals {
   config_without_scanning = yamlencode({
-    logging = "info"
+    logging = var.logging
     rules   = []
     ingestors = [
       {
@@ -12,7 +12,7 @@ locals {
   })
 
   config_with_scanning = yamlencode({
-    logging = "info"
+    logging = var.logging
     rules   = []
     ingestors = concat(
       [

--- a/modules/services/cloud-connector/variables.tf
+++ b/modules/services/cloud-connector/variables.tf
@@ -122,3 +122,9 @@ variable "is_organizational" {
   default     = false
   description = "whether secure-for-cloud should be deployed in an organizational setup"
 }
+
+variable "logging" {
+  type        = string
+  default     = "info"
+  description = "log level: info or debug"
+}


### PR DESCRIPTION
feat: enable log level parameter under single-subscription installation, which allows to set the logs to debug level, apart from info level.

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-azurerm-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
