### PR TITLE
fix: Exclude disabled & deleted subscriptions

### DIFF
--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -2,8 +2,8 @@ data "azurerm_subscription" "current" {}
 data "azurerm_subscriptions" "available" {}
 
 locals {
-  # List all available subscriptions
-  available_subscriptions = data.azurerm_subscriptions.available.subscriptions
+  # List all available subscriptions (exclude disabled and deleted subscriptions)
+  available_subscriptions = [for s in data.azurerm_subscriptions.available.subscriptions : s if (s.state != "Disabled" && s.state != "Deleted")]
 
   # If a list of subscriptions is provided, use that. Otherwise, use all available subscriptions that match the current tenant.
   in_scope_subscription_ids = length(var.subscription_ids) == 0 ? [for s in local.available_subscriptions : s.subscription_id if s.tenant_id == data.azurerm_subscription.current.tenant_id] : var.subscription_ids


### PR DESCRIPTION
`azurerm_subscriptions` returns all subscriptions including disabled & deleted subscriptions. Attempting to provision resources in these will fail, so the PR adds a filter that removes them from the list of subscriptions to be provisioned.